### PR TITLE
Standardized Date Libary to be dayjs

### DIFF
--- a/src/books/books.11tydata.js
+++ b/src/books/books.11tydata.js
@@ -1,9 +1,11 @@
-const { DateTime } = require('luxon');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+dayjs.extend(utc);
 
 module.exports = {
 	layout: 'layouts/book-notes.html',
 	tags: 'booknotes',
 	eleventyComputed: {
-		dateString: ({ page }) => DateTime.fromJSDate(page.date, { zone: 'utc' }).toLocaleString(DateTime.DATE_FULL),
+		dateString: ({ page }) => dayjs.utc(page.date).format('MMMM D, YYYY'),
 	}
 };

--- a/src/collections/stats.js
+++ b/src/collections/stats.js
@@ -1,7 +1,10 @@
 const { getUniqueValues } = require('../lib/Utilities.js');
 const { getBlogPostsAndReadingLogs } = require("../lib/CollectionHelpers");
 const tagUrl = require('../filters/tagurl-filter.js');
-const { DateTime } = require('luxon');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+
+dayjs.extend(utc);
 
 const availableColors = [
 	'#ff0000',
@@ -12,7 +15,7 @@ const availableColors = [
 	'#aa00ff',
 ];
 
-const getYear = (date) => DateTime.fromJSDate(date, { zone: 'utc' }).toFormat('yyyy');
+const getYear = (date) => dayjs.utc(date).format('YYYY');
 
 const getPostsByYearData = (posts) => {
 	const postsByYear = [];

--- a/src/filters/date-filter.js
+++ b/src/filters/date-filter.js
@@ -1,9 +1,12 @@
-const { DateTime } = require('luxon');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+dayjs.extend(utc);
+
 
 module.exports = (dateObj, format = 'MMMM D, YYYY', zone) => {
 	if (typeof dateObj === 'string') {
 		dateObj = new Date(dateObj);
 	}
 
-	return DateTime.fromJSDate(dateObj, { zone: 'utc' }).toLocaleString(DateTime.DATE_FULL)
+	return dayjs.utc(dateObj).format(format);
 };

--- a/src/posts/posts.11tydata.js
+++ b/src/posts/posts.11tydata.js
@@ -1,9 +1,11 @@
-const { DateTime } = require('luxon');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+dayjs.extend(utc);
 
 module.exports = {
     layout: 'layouts/blog-post.html',
     tags: 'post',
     eleventyComputed: {
-        dateString: ({ page }) => DateTime.fromJSDate(page.date, { zone: 'utc' }).toLocaleString(DateTime.DATE_FULL),
+        dateString: ({ page }) => dayjs.utc(page.date).format('MMMM D, YYYY'),
     }
 };

--- a/src/reading-log/reading-log.11tydata.js
+++ b/src/reading-log/reading-log.11tydata.js
@@ -1,9 +1,11 @@
-const { DateTime } = require('luxon');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+dayjs.extend(utc);
 
 module.exports = {
 	layout: 'layouts/reading-log.html',
 	tags: 'readinglog',
 	eleventyComputed: {
-		dateString: ({ page }) => DateTime.fromJSDate(page.date, { zone: 'utc' }).toLocaleString(DateTime.DATE_FULL),
+		dateString: ({ page }) => dayjs.utc(page.date).format('MMMM D, YYYY'),
 	}
 };


### PR DESCRIPTION
# Work Done
Converted `luxon` uses to be [dayjs](https://day.js.org/en/).

# Associated Issue
- Closes #77